### PR TITLE
returning the data

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,6 +94,8 @@ exports.reload = function(opts) {
   if (!stat.isDirectory()) return;
 
   load(opts.path, opts.scope, opts);
+
+  return opts.scope;
 };
 
 /**


### PR DESCRIPTION
hey @silas 

@liquidninja24 and I wanted to do something a bit funky, like require fixtures from another directory. returning the `opts.scope`/`data`made my use case work.

``` javascript
var fixtures = require('fixturefiles');
fixtures.another = {
    path: __dirname + '/another/magical/set/of/fixtures',
    scope: {}
};
fixtures.another = fixtures.reload(fixtures.another);
```

any qualms about returning, in addition to supporting `exports` ?
